### PR TITLE
chore(ci-cd): add draft release check, release-drafter and autolabeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,113 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+  - title: "Performance"
+    labels:
+      - "performance"
+  - title: "Refactoring"
+    labels:
+      - "refactor"
+  - title: "Tests"
+    labels:
+      - "tests"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+  - title: "Dependencies"
+    collapse-after: 3
+    labels:
+      - "dependencies"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+
+exclude-labels:
+  - "skip-changelog"
+  - "duplicate"
+  - "invalid"
+  - "wontfix"
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+      - "feature"
+      - "enhancement"
+  patch:
+    labels:
+      - "patch"
+      - "bug"
+      - "dependencies"
+      - "chore"
+      - "refactor"
+      - "performance"
+      - "tests"
+      - "documentation"
+  default: patch
+
+autolabeler:
+  - label: "feature"
+    branch:
+      - '/feat(ure)?\/.+/'
+    title:
+      - "/^feat/i"
+  - label: "bug"
+    branch:
+      - '/fix\/.+/'
+    title:
+      - "/^fix/i"
+  - label: "chore"
+    branch:
+      - '/chore\/.+/'
+    title:
+      - "/^chore(?!\\(deps\\))/i"
+  - label: "refactor"
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - "/^refactor/i"
+  - label: "documentation"
+    branch:
+      - '/docs?\/.+/'
+    title:
+      - "/^docs?/i"
+    files:
+      - "*.md"
+  - label: "performance"
+    branch:
+      - '/perf\/.+/'
+    title:
+      - "/^perf/i"
+  - label: "tests"
+    branch:
+      - '/tests?\/.+/'
+    title:
+      - "/^tests?/i"
+  - label: "dependencies"
+    branch:
+      - '/depend(encies|abot)\/.+/'
+    title:
+      - "/^chore\\(deps\\)/i"
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,0 +1,16 @@
+name: Auto Labeler
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  auto_label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@a6a982fee9675c45c1765e9fa5308f7d6c3ecbd4 # v7.2.0

--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -13,4 +13,4 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter/autolabeler@a6a982fee9675c45c1765e9fa5308f7d6c3ecbd4 # v7.2.0
+      - uses: release-drafter/release-drafter/autolabeler@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0

--- a/.github/workflows/cd-draft.yml
+++ b/.github/workflows/cd-draft.yml
@@ -1,0 +1,71 @@
+name: CD (Draft Release)
+
+on:
+  release:
+    types: [created]
+
+permissions: {}
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  PACKAGE_NAME: RESTCountries.NET
+  PACKAGE_TEST_VERSION: "1.0.0"
+
+jobs:
+  verify-nuget-key:
+    if: github.event.release.draft == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check NuGet API key validity # zizmor: ignore[use-trusted-publishing]
+        run: |
+          echo "Downloading $PACKAGE_NAME $PACKAGE_TEST_VERSION to validate API key"
+          if ! curl -fsSL -o "$PACKAGE_NAME.$PACKAGE_TEST_VERSION.nupkg" \
+            "https://www.nuget.org/api/v2/package/$PACKAGE_NAME/$PACKAGE_TEST_VERSION"; then
+            echo "::error::Failed to download test package"
+            exit 1
+          fi
+
+          echo "Pushing package to verify NuGet API key validity"
+          if ! dotnet nuget push "$PACKAGE_NAME.$PACKAGE_TEST_VERSION.nupkg" \
+            -k $NUGET_AUTH_TOKEN \
+            -s https://api.nuget.org/v3/index.json \
+            --skip-duplicate; then
+            echo "::error::NuGet API key is invalid or expired. Rotate the NUGET_API_KEY secret and retry."
+            exit 1
+          fi
+
+          echo "API key is valid"
+          rm -f "$PACKAGE_NAME.$PACKAGE_TEST_VERSION.nupkg"
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+
+  build:
+    if: github.event.release.draft == true
+    needs: verify-nuget-key
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build
+        run: dotnet build --configuration Release
+        working-directory: ./src/RESTCountries.NET
+
+      - name: Run unit tests
+        run: dotnet test --configuration Release
+        working-directory: ./tests/RESTCountries.NET.Tests
+
+      - name: Pack
+        run: dotnet pack --configuration Release -o nupkg
+        working-directory: ./src/RESTCountries.NET

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,4 +13,4 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: release-drafter/release-drafter@a6a982fee9675c45c1765e9fa5308f7d6c3ecbd4 # v7.2.0
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@a6a982fee9675c45c1765e9fa5308f7d6c3ecbd4 # v7.2.0


### PR DESCRIPTION
## Summary

- Add a draft release workflow (`cd-draft.yml`) that validates the NuGet API key before publishing, using the Datadog trick (push an already-published package with `--skip-duplicate`)
- Add release-drafter to automatically generate categorized release notes from merged PRs with semver resolution
- Add autolabeler to automatically label PRs based on conventional commit titles, branch names, and changed files

## Details

### Draft release check
- Triggers on `release: created` and runs only for draft releases
- Downloads an existing package (`RESTCountries.NET 1.0.0`) and pushes it with `--skip-duplicate` to validate the API key
- If the key is invalid, the workflow fails early with a clear error message
- Builds, tests, and packs the project to confirm everything is ready

### Release drafter
- Runs on every push to `main` and updates the draft release
- Categorizes PRs into: Features, Bug Fixes, Performance, Refactoring, Tests, Documentation, Dependencies, Maintenance
- Resolves semver version based on labels (`feature`/`enhancement` → minor, everything else → patch, explicit `major`/`minor`/`patch` labels override)

### Autolabeler
- Matches PR titles using conventional commit prefixes (`feat:`, `fix:`, `chore:`, `refactor:`, `doc:`, `perf:`, `test:`)
- Matches branch names (`feat/...`, `fix/...`, `chore/...`, etc.)
- Labels `*.md` file changes as `documentation`
- Correctly distinguishes `chore(deps):` (→ `dependencies`) from `chore:` (→ `chore`)

## New labels created

`major`, `minor`, `patch`, `skip-changelog`, `chore`, `refactor`, `performance`, `tests`