### PR TITLE
chore(ci-cd): add workflow_dispatch trigger to release-drafter

### DIFF
--- a/.github/workflows/cd-draft.yml
+++ b/.github/workflows/cd-draft.yml
@@ -3,6 +3,7 @@ name: CD (Draft Release)
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 permissions: {}
 
@@ -14,7 +15,7 @@ env:
 
 jobs:
   verify-nuget-key:
-    if: github.event.release.draft == true
+    if: github.event.release.draft == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,7 +44,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
 
   build:
-    if: github.event.release.draft == true
+    if: github.event.release.draft == true || github.event_name == 'workflow_dispatch'
     needs: verify-nuget-key
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,7 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- add `workflow_dispatch` to release-drafter and cd-draft workflows so they can be triggered manually from Actions tab
- useful when PR labels/titles are updated after merge and draft needs to be regenerated