### PR TITLE
chore(ci-cd): remove collapse-after from dependencies category

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,7 +22,6 @@ categories:
     labels:
       - "documentation"
   - title: "Dependencies"
-    collapse-after: 3
     labels:
       - "dependencies"
   - title: "Maintenance"


### PR DESCRIPTION
## Summary

- show all dependency PRs in the release draft instead of collapsing after 3