### PR TITLE
chore(ci-cd): simplify autolabeler and add CI/CD category

### DIFF
--- a/.github/release-drafter-template.yml
+++ b/.github/release-drafter-template.yml
@@ -21,6 +21,9 @@ categories:
   - title: "Documentation"
     labels:
       - "documentation"
+  - title: "CI/CD"
+    labels:
+      - "ci-cd"
   - title: "Dependencies"
     labels:
       - "dependencies"
@@ -52,6 +55,7 @@ version-resolver:
       - "bug"
       - "dependencies"
       - "chore"
+      - "ci-cd"
       - "refactor"
       - "performance"
       - "tests"
@@ -59,48 +63,35 @@ version-resolver:
   default: patch
 
 autolabeler:
+  - label: "ci-cd"
+    title:
+      - "/^chore\\((ci-?cd|actions|workflows?)\\)/i"
+  - label: "dependencies"
+    title:
+      - "/^chore\\(deps\\)/i"
   - label: "feature"
-    branch:
-      - '/feat(ure)?\/.+/'
     title:
       - "/^feat/i"
   - label: "bug"
-    branch:
-      - '/fix\/.+/'
     title:
       - "/^fix/i"
   - label: "chore"
-    branch:
-      - '/chore\/.+/'
     title:
-      - "/^chore(?!\\(deps\\))/i"
+      - "/^chore(?!\\()/i"
   - label: "refactor"
-    branch:
-      - '/refactor\/.+/'
     title:
       - "/^refactor/i"
   - label: "documentation"
-    branch:
-      - '/docs?\/.+/'
     title:
       - "/^docs?/i"
     files:
       - "*.md"
   - label: "performance"
-    branch:
-      - '/perf\/.+/'
     title:
       - "/^perf/i"
   - label: "tests"
-    branch:
-      - '/tests?\/.+/'
     title:
       - "/^tests?/i"
-  - label: "dependencies"
-    branch:
-      - '/depend(encies|abot)\/.+/'
-    title:
-      - "/^chore\\(deps\\)/i"
 
 template: |
   ## What's Changed


### PR DESCRIPTION
## Summary

- add CI/CD category for workflow-related PRs (`ci-cd` label)
- simplify autolabeler to title-only matching, drop all branch matchers
- `ci-cd` label matches `chore(ci-cd)`, `chore(actions)`, `chore(workflow)`
- `chore` label matches plain `chore:` without a scope
- scoped chores (`deps`, `ci-cd`, etc.) are matched first to avoid overlap