### PR TITLE
chore(ci-cd): use released/prereleased triggers per GitHub docs

### DIFF
--- a/.github/workflows/cd-pre-check.yml
+++ b/.github/workflows/cd-pre-check.yml
@@ -2,7 +2,7 @@ name: CD (Pre-release Check)
 
 on:
   release:
-    types: [prereleased]
+    types: [published]
 
 permissions: {}
 
@@ -14,6 +14,7 @@ env:
 
 jobs:
   verify-nuget-key:
+    if: github.event.release.prerelease == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,6 +43,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
 
   build:
+    if: github.event.release.prerelease == true
     needs: verify-nuget-key
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/cd-pre-check.yml
+++ b/.github/workflows/cd-pre-check.yml
@@ -2,7 +2,7 @@ name: CD (Pre-release Check)
 
 on:
   release:
-    types: [created]
+    types: [prereleased]
 
 permissions: {}
 
@@ -14,7 +14,6 @@ env:
 
 jobs:
   verify-nuget-key:
-    if: github.event.release.draft == true || github.event.release.prerelease == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,7 +42,6 @@ jobs:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
 
   build:
-    if: github.event.release.draft == true || github.event.release.prerelease == true
     needs: verify-nuget-key
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 permissions: {}
 
@@ -12,7 +12,6 @@ env:
 
 jobs:
   build:
-    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- CD: use `released` instead of `published` -- only fires for stable releases, no `if` guard needed
- cd-pre-check: use `published` with `if: prerelease == true` -- handles draft-to-prerelease flow correctly since `prereleased` doesn't fire for drafts converted to pre-releases (per GitHub docs)

## Flow

- draft → pre-release → `cd-pre-check` validates NuGet key, builds, tests, packs
- draft → stable release → `cd` builds, tests, packs, publishes to NuGet