### PR TITLE
chore(ci-cd): remove build job from cd-pre-check

### DIFF
--- a/.github/workflows/cd-pre-check.yml
+++ b/.github/workflows/cd-pre-check.yml
@@ -42,32 +42,4 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
 
-  build:
-    if: github.event.release.prerelease == true
-    needs: verify-nuget-key
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Build
-        run: dotnet build --configuration Release
-        working-directory: ./src/RESTCountries.NET
-
-      - name: Run unit tests
-        run: dotnet test --configuration Release
-        working-directory: ./tests/RESTCountries.NET.Tests
-
-      - name: Pack
-        run: dotnet pack --configuration Release -p:Version=${RELEASE_VERSION#v} -o nupkg
-        working-directory: ./src/RESTCountries.NET
-        env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

- remove build job from cd-pre-check, it only needs to validate the NuGet API key
- CI already handles build/test on every PR, no need to duplicate it here