### PR TITLE
chore(ci-cd): trigger zizmor only on workflow file changes

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,12 +3,12 @@ name: Zizmor
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '.github/workflows/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- replace `paths-ignore: '**.md'` with `paths: '.github/workflows/**'` so zizmor only runs when workflow files are changed